### PR TITLE
Optional Jason encoders in Value and Struct

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -17,7 +17,7 @@
          exit_status: 0, if_called_more_often_than: 1, if_nested_deeper_than: 1, excluded_namespaces: ["String"]},
         {Credo.Check.Design.TagTODO, exit_status: 0},
         {Credo.Check.Design.TagFIXME, exit_status: 0},
-        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 21}
+        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 25}
       ]
     }
   ]

--- a/lib/tyyppi/struct.ex
+++ b/lib/tyyppi/struct.ex
@@ -244,7 +244,12 @@ defmodule Tyyppi.Struct do
         end
       end
 
-    [declaration, validation, casts_and_validates, update]
+    jason =
+      if Code.ensure_loaded?(Jason.Encoder),
+        do: [quote(do: @derive(Jason.Encoder))],
+        else: []
+
+    jason ++ [declaration, validation, casts_and_validates, update]
   end
 
   @doc "Puts the value to target under specified key, if passes validation"

--- a/lib/tyyppi/value.ex
+++ b/lib/tyyppi/value.ex
@@ -460,15 +460,15 @@ defmodule Tyyppi.Value do
 
     def inspect(%Tyyppi.Value{value: value, __meta__: %{errors: errors}}, opts)
         when length(errors) > 0 do
-      concat(["‹❌#{inspect(Keyword.keys(errors))} ", to_doc(value, opts), "›"])
+      concat(["‹✗#{inspect(Keyword.keys(errors))} ", to_doc(value, opts), "›"])
     end
 
     def inspect(%Tyyppi.Value{value: value, __meta__: %{defined?: true}}, opts) do
-      concat(["‹✔️", to_doc(value, opts), "›"])
+      concat(["‹✓", to_doc(value, opts), "›"])
     end
 
     def inspect(%Tyyppi.Value{value: value}, opts) do
-      concat(["‹❓", to_doc(value, opts), "›"])
+      concat(["‹‽", to_doc(value, opts), "›"])
     end
   end
 end

--- a/lib/tyyppi/value/encodings.ex
+++ b/lib/tyyppi/value/encodings.ex
@@ -1,0 +1,6 @@
+defmodule Tyyppi.Value.Encodings do
+  @moduledoc false
+
+  @spec pid(value :: pid(), opts :: keyword()) :: binary()
+  def pid(pid, _opts \\ []), do: inspect(:erlang.pid_to_list(pid))
+end

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,8 @@ defmodule Tyyppi.MixProject do
     [
       {:boundary, "~> 0.4", runtime: false},
       {:formulae, "~> 0.8", only: [:dev, :test]},
-      {:credo, "~> 1.0", only: [:dev, :ci]},
+      {:jason, "~> 1.0", only: [:dev, :test, :ci]},
+      {:credo, "~> 1.0", only: [:dev, :test, :ci]},
       {:dialyxir, "~> 1.0", only: [:dev, :test, :ci], runtime: false},
       {:ex_doc, "~> 0.11", only: :dev}
     ]

--- a/test/tyyppi/value_test.exs
+++ b/test/tyyppi/value_test.exs
@@ -213,4 +213,24 @@ defmodule Test.Tyyppi.Value do
     assert %{__meta__: %{defined?: false, errors: [type: [expected: "struct()", got: 42]]}} =
              put_in(Value.struct(), [:value], 42)
   end
+
+  test "jason" do
+    assert Jason.encode(Value.integer(42)) == {:ok, "42"}
+    assert Jason.encode(Value.any(42)) == {:ok, "42"}
+    assert Jason.encode(Value.atom(:ok)) == {:ok, ~S|"ok"|}
+    assert Jason.encode(Value.string(42)) == {:ok, ~S|"42"|}
+    assert Jason.encode(Value.boolean(true)) == {:ok, "true"}
+    assert Jason.encode(Value.integer(42)) == {:ok, "42"}
+    assert Jason.encode(Value.non_neg_integer(42)) == {:ok, "42"}
+    assert Jason.encode(Value.pos_integer(42)) == {:ok, "42"}
+    assert Jason.encode(Value.timeout(:infinity)) == {:ok, ~S|"infinity"|}
+    assert Jason.encode(Value.pid(self())) == {:ok, self() |> :erlang.pid_to_list() |> inspect()}
+    # assert Jason.encode(Value.mfa(42)) == {:ok, "42"}
+    # assert Jason.encode(Value.mod_arg(42)) == {:ok, "42"}
+    # assert Jason.encode(Value.fun(42)) == {:ok, "42"}
+    assert Jason.encode(Value.one_of(42, [42, :ok])) == {:ok, "42"}
+    # assert Jason.encode(Value.formulae(42)) == {:ok, "42"}
+    assert Jason.encode(Value.list([42], Tyyppi.parse(integer()))) == {:ok, "[42]"}
+    # assert Jason.encode(Value.struct(42)) == {:ok, "42"}
+  end
 end


### PR DESCRIPTION
Custom encoders and rtansparent fallback to `Jason.Encoder` if `Jason` is presented.